### PR TITLE
Feature: Adding RIOT submodule & hello world example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Nodes/RIOT"]
+	path = Nodes/RIOT
+	url = git@github.com:RIOT-OS/RIOT.git

--- a/Nodes/hello-world/Makefile
+++ b/Nodes/hello-world/Makefile
@@ -1,0 +1,18 @@
+# name of your application
+APPLICATION = hello-world
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= pba-d-01-kw2x
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../RIOT
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/Nodes/hello-world/README.md
+++ b/Nodes/hello-world/README.md
@@ -1,0 +1,56 @@
+# Hello World!
+
+This is a basic example how to use RIOT in your embedded application.
+It prints out the famous text `Hello World!`.
+The code itself may look like your usual *C* beginners hello-world example.
+
+## Task 1
+Build the application, flash the firmware and connect to the board through the serial port.
+
+**1. Open a terminal and navigate to the application directory.**
+
+**2. Build the application by executing GNU Make.**
+```sh
+$ make all
+```
+
+**3. Connect your board using the USB cable.**
+
+**4. Flash the built firmware image into the board's memory.**
+```sh
+$ make flash
+```
+**5. Initiate a serial communication with the board.**
+```sh
+$ make term
+```
+
+**6. Reset your board by pressing the 'Reset' button. You should see the "Hello World!" message.**
+
+```sh
+main(): This is RIOT! (Version: 2022.01)
+Hello World!
+```
+
+**7. To exit the serial terminal program, press Ctrl + C.**
+
+Optionally, you can run all the commands above as a single line:
+```sh
+$ make all flash term
+```
+
+## Intro to RIOT build system
+This example should foremost give you an overview how to use the Makefile system.
+Let's take a look at the `Makefile` file in the application directory:
+
+* First you must give your application a name, which is commonly the same as the name of the directory it resides in.
+
+* Then you can define a default BOARD for which the application was written.
+  By using e.g. `make BOARD=nrf52840dk` you can override the default board.
+
+* The variable `RIOTBASE` contains an absolute or relative path to the directory where you have checked out RIOT.
+  If your code resides in a subdirectory of RIOT, then you can use `$(CURDIR)` as it's done in here.
+
+* The variable `QUIET`, which is either `1` or `0`, defines whether to print verbose compile information, or hide them, respectively.
+
+* The last line of your Makefile must be `include $(RIOTBASE)/Makefile.include`.

--- a/Nodes/hello-world/main.c
+++ b/Nodes/hello-world/main.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Hello World application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+    puts("Hello World!");
+
+    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+    return 0;
+}


### PR DESCRIPTION
Hi! 

This PR adds the RIOT-OS repository as a submodule tagged to the latest release 2022.01. 
Additionally, it adds an hello world example to make it easy to test if everything is working as expected. 


_The hello world compiles & builds the expected artefacts on my machine. I did not run the binary on a development board_