### PR TITLE
Fix: Switching to HTTPS instead of git for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Nodes/RIOT"]
 	path = Nodes/RIOT
-	url = git@github.com:RIOT-OS/RIOT.git
+	url = https://github.com/RIOT-OS/RIOT.git
+


### PR DESCRIPTION
fix(submodules): Switching to https instead of ssh, eliminates  the requirement  of users having ssh keys