### PR TITLE
Draft: Nodes: Adding a puzzle module to handle coap endpoints

### DIFF
--- a/Nodes/modules/puzzle_coap/Makefile
+++ b/Nodes/modules/puzzle_coap/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/Nodes/modules/puzzle_coap/Makefile.dep
+++ b/Nodes/modules/puzzle_coap/Makefile.dep
@@ -1,0 +1,7 @@
+# add the module dependencies here
+# USEMODULE += random
+
+USEMODULE += gcoap
+USEMODULE += cord_ep_standalone
+USEMODULE += uri_parser
+USEPKG += tinycbor

--- a/Nodes/modules/puzzle_coap/Makefile.include
+++ b/Nodes/modules/puzzle_coap/Makefile.include
@@ -1,0 +1,3 @@
+# Use an immediate variable to evaluate `MAKEFILE_LIST` now
+USEMODULE_INCLUDES_puzzle_coap_module := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_puzzle_coap_module)

--- a/Nodes/modules/puzzle_coap/include/puzzle_coap.h
+++ b/Nodes/modules/puzzle_coap/include/puzzle_coap.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef EXTERNAL_PUZZLE_COAP_H
+#define EXTERNAL_PUZZLE_COAP_H
+
+#include <stdio.h>
+
+#include "uri_parser.h"
+#include "net/gcoap.h"
+#include "net/cord/common.h"
+#include "net/cord/ep.h"
+#include "net/sock/util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PUZZLE_RESOURCE_TYPE ";rt=\"puzzle\";obs"
+
+/* 119 is the max size without touching the gcoap.h */
+/* the default CONFIG_GCOAP_PDU_BUF_SIZE is 128 */
+#define CBOR_BUF_SIZE 100
+
+/**
+ * Puzzle info structure 
+ */
+typedef struct {
+    bool (*get_solved_handler)(void);   /**< bool handler thats get called to see if a puzzle is solved */
+    bool (*get_ready_handler)(void);    /**< bool handler thats get called to see if a puzzle is ready or in maintainance */
+    void (*set_ready_handler)(bool maintainance);/**< void handler thats get called to set a puzzle in ready or maintainance mode*/
+    const char *resource_dir_uri;   /**< char* URI to a CoRE RD */
+    const char *name;               /**< char* name of the puzzle */
+} puzzle_t;
+
+void puzzle_init(const puzzle_t *puzzle);
+void puzzle_update(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* EXTERNAL_PUZZLE_COAP_H */

--- a/Nodes/modules/puzzle_coap/puzzle_coap.c
+++ b/Nodes/modules/puzzle_coap/puzzle_coap.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       The puzzle_coap module, provides automated resource & RD handling
+ *
+ * @author      Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include "puzzle_coap.h"
+#include "cbor.h"
+
+static const puzzle_t *_puzzle_info;
+
+static ssize_t _puzzle_info_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _puzzle_ready_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _puzzle_maintainance_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t _puzzle_encoder(const coap_resource_t *resource, char *buf, size_t maxlen, coap_link_encoder_ctx_t *context);
+
+
+/* CoAP resources. Must be sorted by path (ASCII order). */
+static coap_resource_t _resources[] = {
+    { "/node/info", COAP_GET, _puzzle_info_handler, NULL },
+    { "/node/maintainance", COAP_PUT, _puzzle_maintainance_handler, NULL },
+    { "/node/ready", COAP_PUT, _puzzle_ready_handler, NULL },
+};
+
+
+static gcoap_listener_t _default_listener = {
+    _resources,
+    ARRAY_SIZE(_resources),
+    GCOAP_SOCKET_TYPE_UDP,
+    _puzzle_encoder,
+    NULL,
+    NULL
+};
+
+static int _make_sock_ep(sock_udp_ep_t *ep, uri_parser_result_t *uri)
+{
+    ep->port = 0;
+    if (sock_udp_name2ep(ep, uri->host) < 0) {
+        return -1;
+    }
+
+    /* if netif not specified in addr */
+    if ((ep->netif == SOCK_ADDR_ANY_NETIF) && (gnrc_netif_numof() == 1)) {
+        /* assign the single interface found in gnrc_netif_numof() */
+        ep->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+    }
+    ep->family  = AF_INET6;
+    if (uri->port_len == 0) {
+        ep->port = COAP_PORT;
+    } else {
+        ep->port = atoi(uri->port); // Fix me!
+    }
+    return 0;
+}
+
+static size_t _puzzle_build_cbor_buffer(uint8_t *cborbuf, size_t len)
+{
+    /* 
+     * Encode the puzzle info in cbor:
+     * {
+     *  "name": <string>,
+     *  "nodeState": <'provisioned'|'standby'>,
+     *  "puzzleState": <'solved'|'ready'|'maintainance'>, 
+     * }
+     */
+    assert(_puzzle_info);
+
+    CborEncoder encoder, mapEncoder;
+    cbor_encoder_init(&encoder, cborbuf, len, 0);
+    cbor_encoder_create_map(&encoder, &mapEncoder, 3);
+    cbor_encode_text_stringz(&mapEncoder, "name");
+    /* Potentially dangerous! The string might not be null terminated */
+    cbor_encode_text_stringz(&mapEncoder, _puzzle_info->name);
+
+    cbor_encode_text_stringz(&mapEncoder, "puzzleState");
+    /* are we ready or are we in maintainance mode? */
+    if (_puzzle_info->get_ready_handler()){
+        if (_puzzle_info->get_solved_handler()){
+            cbor_encode_text_stringz(&mapEncoder, "solved");
+        } else {
+            cbor_encode_text_stringz(&mapEncoder, "ready");
+        }
+    } else {
+        cbor_encode_text_stringz(&mapEncoder, "maintainance");
+    }
+
+    cbor_encode_text_stringz(&mapEncoder, "nodeState");
+    cbor_encode_text_stringz(&mapEncoder, "standby"); 
+
+    cbor_encoder_close_container(&encoder, &mapEncoder);
+    return cbor_encoder_get_buffer_size(&encoder, cborbuf);
+}
+
+
+static ssize_t _build_cbor_coap_packet(coap_pkt_t *pdu, uint8_t *buf, size_t len)
+{
+    uint8_t cborbuf[CBOR_BUF_SIZE];
+
+    /* set the format option to CBOR */
+    coap_opt_add_format(pdu, COAP_FORMAT_CBOR);
+
+    /* finish the options sections */
+    /* it is important to keep track of the amount of used bytes (resp_len) */
+    size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
+    size_t cbor_len = _puzzle_build_cbor_buffer(cborbuf, sizeof(cborbuf));
+
+
+    if (pdu->payload_len >= cbor_len && cbor_len < sizeof(cborbuf)){
+        memcpy(pdu->payload, cborbuf, cbor_len);
+        return resp_len + cbor_len;
+    } else {
+        /* in this case we use a simple convenience function to create the
+         * response, it only allows to set a payload and a response code. */
+        puts("puzzle_coap: msg buffer too small for given puzzle cbor object");
+        return gcoap_response(pdu, buf, len, COAP_CODE_INTERNAL_SERVER_ERROR);
+    }
+}
+
+
+void puzzle_init(const puzzle_t *puzzle)
+{
+    assert(puzzle);
+    assert(puzzle->name);
+    assert(puzzle->resource_dir_uri);
+    assert(puzzle->get_solved_handler);
+    assert(puzzle->get_ready_handler);
+    assert(puzzle->set_ready_handler);
+    _puzzle_info = puzzle;
+
+    sock_udp_ep_t remote;
+    uri_parser_result_t uri_result;
+    assert(uri_parser_is_absolute_string(puzzle->resource_dir_uri));
+    assert(uri_parser_process_string(&uri_result, puzzle->resource_dir_uri) == 0);
+    assert(_make_sock_ep(&remote, &uri_result) == 0);
+
+    gcoap_register_listener(&_default_listener);
+
+    puts("Registering with RD now, this may take a short while...");
+    if (cord_ep_register(&remote, NULL) != CORD_EP_OK) {
+        puts("error: registration failed");
+        return;
+    } else {
+        puts("registration successfull");
+    }
+}
+
+
+void puzzle_update(void)
+{
+    size_t len = 0;
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
+    coap_pkt_t pdu;
+
+    switch (gcoap_obs_init(&pdu, buf, sizeof(buf), &_resources[0])) {
+        case GCOAP_OBS_INIT_OK:
+            len = _build_cbor_coap_packet(&pdu, buf, sizeof(buf));
+            if(gcoap_obs_send(buf, len, &_resources[0]) == 0) {
+                puts("Notification failed to send");
+            }
+            break;
+        case GCOAP_OBS_INIT_ERR:
+            puts("Notification of the observers failed");
+            break;
+        case GCOAP_OBS_INIT_UNUSED:
+            break;
+    }
+}
+
+/*
+ * Server callback for /node/info. Accepts only GET.
+ *
+ * GET: Returns the puzzle status in CBOR
+ */
+static ssize_t _puzzle_info_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+{
+    (void)ctx;
+    /* since the init functions asserts all other members, 
+     * its safe to just assert the base pointer */
+    assert(_puzzle_info);
+
+    /* initialize a new coap response */
+    gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+
+    return _build_cbor_coap_packet(pdu, buf, len);
+
+}
+
+/*
+ * Server callback for /node/ready. Accepts only PUT.
+ * Sets the puzzle into the ready state
+ * PUT: Returns the puzzle status in CBOR
+ */
+static ssize_t _puzzle_ready_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+{
+    (void)ctx;
+    /* since the init functions asserts all other members, 
+     * its safe to just assert the base pointer */
+    assert(_puzzle_info);
+
+    unsigned method = coap_method2flag(coap_get_code_detail(pdu));
+
+    switch (method) {
+        case COAP_PUT:
+            _puzzle_info->set_ready_handler(false);
+            break;
+        default:
+            /* we don't care about anything else */
+            return gcoap_response(pdu, buf, len, COAP_CODE_BAD_REQUEST);
+    }
+
+
+    /* initialize a new coap response */
+    gcoap_resp_init(pdu, buf, len, COAP_CODE_CHANGED);
+
+    return _build_cbor_coap_packet(pdu, buf, len);
+
+}
+
+
+/*
+ * Server callback for /node/maintainance. Accepts only PUT.
+ * Sets the puzzle into the ready state
+ * PUT: Returns the puzzle status in CBOR
+ */
+static ssize_t _puzzle_maintainance_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx)
+{
+    (void)ctx;
+    /* since the init functions asserts all other members, 
+     * its safe to just assert the base pointer */
+    assert(_puzzle_info);
+
+    unsigned method = coap_method2flag(coap_get_code_detail(pdu));
+
+    switch (method) {
+        case COAP_PUT:
+            _puzzle_info->set_ready_handler(true);
+            break;
+        default:
+            /* we don't care about anything else */
+            return gcoap_response(pdu, buf, len, COAP_CODE_BAD_REQUEST);
+    }
+
+
+    /* initialize a new coap response */
+    gcoap_resp_init(pdu, buf, len, COAP_CODE_CHANGED);
+
+    return _build_cbor_coap_packet(pdu, buf, len);
+
+}
+
+
+/* Adds link format params to resource list */
+static ssize_t _puzzle_encoder(const coap_resource_t *resource, char *buf,
+                            size_t maxlen, coap_link_encoder_ctx_t *context) {
+    ssize_t res = gcoap_encode_link(resource, buf, maxlen, context);
+
+    if (res > 0) {
+        if (strlen(PUZZLE_RESOURCE_TYPE) < (maxlen - res)){
+            if (buf) {
+                memcpy(buf+res, PUZZLE_RESOURCE_TYPE, strlen(PUZZLE_RESOURCE_TYPE));
+            }
+            res += strlen(PUZZLE_RESOURCE_TYPE);
+        }
+    }
+
+    return res;
+}

--- a/Nodes/puzzle_example/Makefile
+++ b/Nodes/puzzle_example/Makefile
@@ -1,0 +1,35 @@
+# name of the application
+APPLICATION = example
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= ../RIOT
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# For the coap_client
+USEMODULE += od
+
+USEMODULE += netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+USEMODULE += gnrc_icmpv6_echo
+USEMODULE += netutils
+
+USEMODULE += fmt
+USEMODULE += xtimer
+
+USEMODULE += puzzle_coap
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include ../common.mk

--- a/Nodes/puzzle_example/README.md
+++ b/Nodes/puzzle_example/README.md
@@ -1,0 +1,28 @@
+# Example on how to use the puzzle_coap module
+
+The module takes care of handling the coap API for a given puzzle.
+It also registers the puzzle at the RD from the provided URI.
+
+Puzzles are defined with this struct:
+```C++
+typedef struct {
+    bool (*get_solved_handler)(void);   /**< bool handler thats get called to see if a puzzle is solved */
+    bool (*get_ready_handler)(void);    /**< bool handler thats get called to see if a puzzle is ready or in maintainance */
+    void (*set_ready_handler)(bool maintainance);/**< void handler thats get called to set a puzzle in ready or maintainance mode*/
+    const char *resource_dir_uri;   /**< char* URI to a CoRE RD */
+    const char *name;               /**< char* name of the puzzle */
+} puzzle_t;
+```
+
+The member `name` must be set to the puzzles name. 
+The handler `get_solved_handler` MUST point to a function that can check if the puzzle is solved and returns either true or false. 
+The handler `get_ready_handler` MUST point to a function that can check if the puzzle is ready to be solved and returns either true or false.
+The handler `set_ready_handler` MUST point to a function that switches the puzzle into either maintainance- or ready mode, depending on the parameter `maintainance`.
+The uri `resource_dir_uri` MUST be set to a correct URI. 
+The module will still provide a CoAP endpoint even if the registration is unsuccessfull.
+
+To initialise the module, a pointer to the struct is passed to `puzzle_init(..)`. The passed pointer *MUST* be valid for the lifetime of the application.
+
+After that, the puzzle API e.g. `/node/info` is available, which returns a CBOR encoded status of the puzzle.
+
+If your puzzles state changes you MUST call `puzzle_update()`, this will notify potential observers.

--- a/Nodes/puzzle_example/coap_client.c
+++ b/Nodes/puzzle_example/coap_client.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       gcoap CLI support
+ *
+ * @author      Ken Bannister <kb2ma@runbox.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "shell.h"
+#include "fmt.h"
+#include "net/gcoap.h"
+#include "net/utils.h"
+#include "od.h"
+
+uint16_t req_count = 0;
+
+/*
+ * Response callback.
+ */
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote)
+{
+    (void)remote;       /* not interested in the source currently */
+
+    if (memo->state == GCOAP_MEMO_TIMEOUT) {
+        printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
+        return;
+    }
+    else if (memo->state != GCOAP_MEMO_RESP) {
+        printf("gcoap: error in response\n");
+        printf("state: %d\n", memo->state);
+        return;
+    }
+
+    char *class_str = (coap_get_code_class(pdu) == COAP_CLASS_SUCCESS) ? "Success" : "Error";
+
+    printf("gcoap: response %s, code %1u.%02u", class_str,
+                                                coap_get_code_class(pdu),
+                                                coap_get_code_detail(pdu));
+    if (pdu->payload_len) {
+        unsigned content_type = coap_get_content_type(pdu);
+        if (content_type == COAP_FORMAT_TEXT
+                || content_type == COAP_FORMAT_LINK
+                || coap_get_code_class(pdu) == COAP_CLASS_CLIENT_FAILURE
+                || coap_get_code_class(pdu) == COAP_CLASS_SERVER_FAILURE) {
+            /* Expecting diagnostic payload in failure cases */
+            printf(", %u bytes\n%.*s\n", pdu->payload_len, pdu->payload_len,
+                                                          (char *)pdu->payload);
+        }
+        else {
+            printf(", %u bytes\n", pdu->payload_len);
+            od_hex_dump(pdu->payload, pdu->payload_len, OD_WIDTH_DEFAULT);
+        }
+    }
+    else {
+        printf(", empty payload\n");
+    }
+}
+
+static bool _parse_endpoint(sock_udp_ep_t *remote,
+                            const char *addr_str, const char *port_str)
+{
+    netif_t *netif;
+
+    /* parse hostname */
+    if (netutils_get_ipv6((ipv6_addr_t *)&remote->addr, &netif, addr_str) < 0) {
+        puts("gcoap_cli: unable to parse destination address");
+        return false;
+    }
+    remote->netif = netif ? netif_get_id(netif) : SOCK_ADDR_ANY_NETIF;
+    remote->family = AF_INET6;
+
+    /* parse port */
+    remote->port = atoi(port_str);
+    if (remote->port == 0) {
+        puts("gcoap_cli: unable to parse destination port");
+        return false;
+    }
+
+    return true;
+}
+
+static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
+{
+    size_t bytes_sent;
+    sock_udp_ep_t remote;
+
+    if (!_parse_endpoint(&remote, addr_str, port_str)) {
+        return 0;
+    }
+
+    bytes_sent = gcoap_req_send(buf, len, &remote, _resp_handler, NULL);
+    if (bytes_sent > 0) {
+        req_count++;
+    }
+    return bytes_sent;
+}
+
+static int _print_usage(char **argv)
+{
+    printf("usage: %s info\n", argv[0]);
+    printf("       %s <get|post|put|delete> <addr>[%%iface] <port> <path> [data]\n",argv[0]);
+    return 1;
+}
+
+static int _coap_info_cmd(void)
+{
+    uint8_t open_reqs = gcoap_op_state();
+
+    printf("CoAP server is listening on port %u\n", CONFIG_GCOAP_PORT);
+    printf(" CLI requests sent: %u\n", req_count);
+    printf("CoAP open requests: %u\n", open_reqs);
+    return 0;
+}
+
+/* map a string to a coap method code */
+int _method_str_to_code(const char *method)
+{
+    if (!strcmp(method, "get")) {
+        return COAP_METHOD_GET;
+    }
+    else if (!strcmp(method, "post")) {
+        return COAP_METHOD_POST;
+    }
+    else if (!strcmp(method, "put")) {
+        return COAP_METHOD_PUT;
+    }
+    else if (!strcmp(method, "delete")) {
+        return COAP_METHOD_DELETE;
+    }
+
+    printf("Unknown method: %s\n", method);
+    return -1;
+}
+
+int gcoap_cli_cmd(int argc, char **argv)
+{
+
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
+    coap_pkt_t pdu;
+    size_t len;
+    int position = 1;
+
+    /* parse user input */
+    if (argc == 1) {
+        /* invalid number of arguments, show help for the command */
+        return _print_usage(argv);
+    }
+
+    if (strcmp(argv[position], "info") == 0) {
+        return _coap_info_cmd();
+    }
+
+    if ((argc != 5) && (argc != 6)) {
+        /* invalid number of arguments, show help for the command */
+        return _print_usage(argv);
+    }
+
+    /* determine which method to use */
+    int code = _method_str_to_code(argv[position]);
+    if (code < 0) {
+        /* unknown method, show help */
+        return _print_usage(argv);
+    }
+
+    position ++;
+
+    char *addr = argv[position++];
+    char *port = argv[position++];
+    char *path = argv[position++];
+
+    /* simple check for the path */
+    if (!path || path[0] != '/') {
+        return _print_usage(argv);
+    }
+
+    char *data = NULL;
+    size_t data_len = 0;
+    if (argc == 6) {
+        data = argv[position++];
+        data_len = strlen(data);
+    }
+    printf("%s\n", path);
+    /* initialize the CoAP request */
+    gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, code, path);
+
+    /* send a confirmable message */
+    coap_hdr_set_type(pdu.hdr, COAP_TYPE_CON);
+
+    /* if there is data, we specify the plain text format and copy the payload */
+    if (data_len) {
+        coap_opt_add_format(&pdu, COAP_FORMAT_TEXT);
+
+        len = coap_opt_finish(&pdu, COAP_OPT_FINISH_PAYLOAD);
+        if (pdu.payload_len >= data_len) {
+            memcpy(pdu.payload, data, data_len);
+            len += data_len;
+        }
+        else {
+            puts("The buffer is too small, reduce the message length");
+            return 1;
+        }
+    } else {
+        len = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
+    }
+
+    printf("gcoap_cli: sending msg ID %u, %u bytes\n", coap_get_id(&pdu), (unsigned) len);
+    if (!_send(buf, len, addr, port)) {
+        puts("gcoap_cli: msg send failed");
+        return -1;
+    }
+    return 0;
+}
+
+/* define CoAP shell command */
+SHELL_COMMAND(coap, "Perform CoAP operations", gcoap_cli_cmd);

--- a/Nodes/puzzle_example/main.c
+++ b/Nodes/puzzle_example/main.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2022 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @brief       Example on using the puzzle_coap module
+ *
+ * @author      Bennet Blischke <bennet.blischke@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "shell.h"
+#include "xtimer.h"
+
+#include "puzzle_coap.h"
+
+#define STARTUP_DELAY   (1U)
+#define MAIN_QUEUE_SIZE (4)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+/* forward declarations */
+static bool _solved(void);
+static bool _ready(void);
+static void _set_ready(bool maintainance);
+
+/* Setting up the puzzle */
+static const puzzle_t puzzle = {
+    .get_solved_handler = _solved,
+    .get_ready_handler = _ready,
+    .set_ready_handler = _set_ready,
+    .name = "Example puzzle",
+    .resource_dir_uri = "coap://[fd00:dead:beef::1]",
+};
+
+static bool _is_solved = false;
+static bool _is_ready = true;
+
+
+int main(void)
+{
+    /* just wait a sec, otherwise the `make falsh term` users 
+     * wouldn't see the first print's and might think the app is hanging */
+    xtimer_sleep(STARTUP_DELAY);
+
+    /* Initialise the puzzle coap module */
+    puzzle_init(&puzzle);
+
+    /* for the thread running the shell */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}
+
+/* dummy shell commande to "solve" this puzzle 
+ * a real puzzle would call `puzzle_update()` everytime it gets 
+ * solved (or when it is no-longer solved). */
+static int _cmd_solve(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    _is_solved = !_is_solved;
+    /* Notify the module about the news */
+    puzzle_update();
+    return 0;
+}
+
+
+/* callback handler for the coap API. Returns if the puzzle is solved */
+static bool _solved(void)
+{
+    return _is_solved;
+}
+
+/* callback handler for the coap API. Returns if the puzzle is ready to be solved */
+static bool _ready(void)
+{
+    return _is_ready;
+}
+
+/* callback handler for the coap API. Is called to set the puzzle in either maintainance or ready mode */
+static void _set_ready(bool maintainance)
+{
+    if (maintainance) {
+        /* We are in maintainance mode now; Open the doors, locks etc.... */
+        _is_ready = false;
+    } else {
+        /* Get back to be ready to play! */
+        _is_ready = true;
+    }
+}
+
+SHELL_COMMAND(puzzle_solve, "Toggle if the puzzle is solved", _cmd_solve);


### PR DESCRIPTION
Hi 👋 

This adds a module (& an example for it)  which, when included and initialised, acts as an abstraction for a specific coap endpoint. The idea behind is to make it simpler to focus on building a puzzle (reading sensors, comparing values) rather than caring about coap endpoints, resources, handler, etc. 

